### PR TITLE
[FIX] Fix db config to use prod in heroku

### DIFF
--- a/models/index.js
+++ b/models/index.js
@@ -4,8 +4,7 @@ var fs        = require('fs');
 var path      = require('path');
 var Sequelize = require('sequelize');
 var basename  = path.basename(module.filename);
-//var env       = process.env.NODE_ENV || 'development';
-var env       = 'development';
+var env       = process.env.NODE_ENV || 'development';
 var config    = require(__dirname + '/../config/config.json')[env];
 var db        = {};
 


### PR DESCRIPTION
Due to the confusing nature of version control, the db config for sequelize was always set to `development`, even when in production. This will restore the proper db configs by resetting the generated `index.js` back to what it originally was. 